### PR TITLE
fix: problemas de centralização e tags erradas

### DIFF
--- a/as DLCs.html
+++ b/as DLCs.html
@@ -666,9 +666,5 @@
 
 
     </head>
-
-    <body>
-
-    </body>
-
+</body>    
 </html>

--- a/as DLCs.html
+++ b/as DLCs.html
@@ -1,509 +1,652 @@
 <!DOCTYPE html>
 <html lang="pt-br">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>as DLCs</title>
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <header>
         <div id="title">
-            <h1>as DLCs</h1>           
+            <h1>as DLCs</h1>
         </div>
-           
+
         <ul>
-            <a href="https://www.youtube.com/watch?v=E4eoHLskxwE&t=3s" id="Desenvolvimento-btn"><li>Desenvolvimento</li></a>
-            <a href="https://www.youtube.com/watch?v=ItQoBbQGMvY&t=223s" id="História-btn"><li>Historia</li></a>
-            <a href="Empresa.html"><li>Empresa</li></a>
-            <a href="jogo.html"><li>O jogo</li></a>
-            <a href="as DLCs.html"><li>as DLCs</li></a>
-            <a href="Lancamentos.html"><li> Lancamentos</li></a>
-            <a href="https://www.youtube.com/watch?v=nZtDYuzMR1E&t=32s" id="Curiosidades-btn"><li>Curiosidades</li></a>
-            <a href="https://store.steampowered.com/app/367520/Hollow_Knight/"id= "Onde comprar- btn"><li>Onde comprar?</li></a>
-          
+            <a href="https://www.youtube.com/watch?v=E4eoHLskxwE&t=3s" id="Desenvolvimento-btn">
+                <li>Desenvolvimento</li>
+            </a>
+            <a href="https://www.youtube.com/watch?v=ItQoBbQGMvY&t=223s" id="História-btn">
+                <li>Historia</li>
+            </a>
+            <a href="Empresa.html">
+                <li>Empresa</li>
+            </a>
+            <a href="jogo.html">
+                <li>O jogo</li>
+            </a>
+            <a href="as DLCs.html">
+                <li>as DLCs</li>
+            </a>
+            <a href="Lancamentos.html">
+                <li> Lancamentos</li>
+            </a>
+            <a href="https://www.youtube.com/watch?v=nZtDYuzMR1E&t=32s" id="Curiosidades-btn">
+                <li>Curiosidades</li>
+            </a>
+            <a href="https://store.steampowered.com/app/367520/Hollow_Knight/" id="Onde comprar- btn">
+                <li>Onde comprar?</li>
+            </a>
+
 
 
         </ul>
     </header>
+
     <head>
-    <!-----as DLCs-->
-    <section class="as DLCs" id="as DLCs">
-        <div class="container">
-            <div class="center">
-        <h2>As DLCs do game</h2>
-        <div id="dov">
-        <img src="images/Hollow knight DLC Grimm troupe grande.jpg">
-        <br><br>
-    </div>
+        <!-----as DLCs-->
+        <section class="as DLCs" id="as DLCs">
+            <div class="container">
+                <div class="center">
+                    <h2>As DLCs do game</h2>
+                    <div id="dov">
+                        <img src="images/Hollow knight DLC Grimm troupe grande.jpg">
+                        <br><br>
+                    </div>
 
-        <div id="dov">
-        <h3>Lançamento da DLC "Tropa do Grimm"</h3>
-    </div>
-        <div id="dov">
-        <p>A DLC “Grimm Troupe” de Hollow Knight é uma das expansões gratuitas mais populares do jogo, lançada em outubro de 2017. 
-        Esta atualização trouxe uma nova narrativa, personagens, desafios e melhorias significativas ao jogo base. 
-        Vamos explorar os detalhes dessa expansão fascinante.</p>
-        <br><br>
-    </div>
-    <br><br>
+                    <div id="dov">
+                        <h3>Lançamento da DLC "Tropa do Grimm"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC “Grimm Troupe” de Hollow Knight é uma das expansões gratuitas mais populares do jogo,
+                            lançada em outubro de 2017.
+                            Esta atualização trouxe uma nova narrativa, personagens, desafios e melhorias significativas
+                            ao jogo base.
+                            Vamos explorar os detalhes dessa expansão fascinante.</p>
+                        <br><br>
+                    </div>
+                    <br><br>
 
-        <div id="dov">
-        <h3>O Que é a “Grimm Troupe”?</h3>
-    </div>
-        <div id="dov">
-        <p>“The Grimm Troupe” é uma expansão que introduz uma nova missão centrada em torno de uma trupe de circo itinerante liderada pelo misterioso Mestre Grimm. 
-        A trupe chega a Hallownest e desencadeia uma série de eventos que envolvem o jogador em uma história sombria e enigmática.</p>
-        <br><br>
-        </div>
+                    <div id="dov">
+                        <h3>O Que é a “Grimm Troupe”?</h3>
+                    </div>
+                    <div id="dov">
+                        <p>“The Grimm Troupe” é uma expansão que introduz uma nova missão centrada em torno de uma trupe
+                            de circo itinerante liderada pelo misterioso Mestre Grimm.
+                            A trupe chega a Hallownest e desencadeia uma série de eventos que envolvem o jogador em uma
+                            história sombria e enigmática.</p>
+                        <br><br>
+                    </div>
 
-       <div id="dov"> 
-    <h3>Principais Adições da DLC “Grimm Troupe"</h3>
-       </div>
-    <br><br>
-    <div id="dov">
-    <h3>Narrativa e Missões</h3>
-    </div>
-    <div id="dov">
-    <p>Convocação da Troupe: O jogador inicia a DLC ao encontrar e acender a "Lanterna do Pesadelo" em uma nova área do Reino Esquecido (Forgotten Crossroads). 
-     Isso convoca a Troupe Grimm para Hallownest.</p>
-    </div>
-    <div id="dov">
-     <p>O Mestre Grimm: Após convocar a trupe, o jogador conhece o Mestre Grimm, que lhes confia a tarefa de coletar “Flamas de Pesadelo” (Nightmare Flames) espalhadas pelo reino.
-    Essas chamas são essenciais para completar o ritual da trupe.</p>
-    <br><br>
-</div>
+                    <div id="dov">
+                        <h3>Principais Adições da DLC “Grimm Troupe"</h3>
+                    </div>
+                    <br><br>
+                    <div id="dov">
+                        <h3>Narrativa e Missões</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Convocação da Troupe: O jogador inicia a DLC ao encontrar e acender a "Lanterna do Pesadelo"
+                            em uma nova área do Reino Esquecido (Forgotten Crossroads).
+                            Isso convoca a Troupe Grimm para Hallownest.</p>
+                    </div>
+                    <div id="dov">
+                        <p>O Mestre Grimm: Após convocar a trupe, o jogador conhece o Mestre Grimm, que lhes confia a
+                            tarefa de coletar “Flamas de Pesadelo” (Nightmare Flames) espalhadas pelo reino.
+                            Essas chamas são essenciais para completar o ritual da trupe.</p>
+                        <br><br>
+                    </div>
 
-<div id="dov">
- <h3>Novos Personagens</h3>
-</div>
-<div id="dov">
-<p>Grimm: O líder enigmático da trupe, que guia o Cavaleiro em uma missão peculiar.
- <br><br>
-</div>
-<div id="dov">
-Brumm: Um membro da trupe que toca o acordeão e oferece pistas e segredos ao jogador.
-<br><br>
-</div>
-<div id="dov">
- Baboons: Pequenos seguidores da trupe, com comportamentos estranhos e divertidos.
-<br><br>
-</div>
-<div id="dov">
-Divine: Uma figura feminina da trupe que se instala na vila e oferece melhorias para os amuletos do jogador.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Novos Chefes</h3>
-</div>
-<div id="dov">
-<p>Grimm: Enfrentado em diferentes formas e dificuldades, ele testa as habilidades do jogador com movimentos rápidos e ataques de fogo.
-<br><br>
-</div>
-<div id="dov">
- Nightmare King Grimm: Uma versão ainda mais poderosa de Grimm, este chefe é notório por sua dificuldade extrema e padrões de ataque complexos.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Novos Amuletos</h3>
-</div>
-<div id="dov">
-<p>A DLC introduz novos amuletos que o jogador pode equipar para ganhar habilidades especiais:</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Amuleto do Grimmchild: Concede um familiar que ajuda em combate, evoluindo conforme o jogador coleta as chamas.</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Amuletos de Confraria: Opções adicionais oferecidas pela Trupe do Grimm, modificando e melhorando as habilidades do jogador de formas únicas.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Elementos Adicionais</h3>
-</div>
-<div id="dov">
-<p>Conteúdo de História: A DLC expande o lore do mundo de Hollow Knight, oferecendo mais detalhes sobre a misteriosa trupe e sua conexão com Hallownest.</p>
- <br><br>
-</div>
-<div id="dov">
-<p>Novos Desafios e Inimigos: Além dos novos chefes, a DLC adiciona novos tipos de inimigos e desafios para os jogadores superarem.</p>
- <br><br>
-</div>
-<div id="dov">
- <p>Múltiplos Finais: Dependendo das escolhas do jogador ao longo da missão, diferentes desfechos podem ser alcançados, oferecendo rejogabilidade e variação na narrativa.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Atmosfera e Arte</h3>
-</div>
-<div id="dov">
-<p>A Trupe do Grimm traz uma estética única ao jogo, com sua temática circense sombria e trilha sonora evocativa, composta por Christopher Larkin. A arte e o design de som complementam perfeitamente a sensação misteriosa e encantadora que a DLC busca transmitir.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Impacto e Recepção</h3>
-</div>
-<div id="dov">
-<p>A DLC da Trupe do Grimm foi amplamente aclamada por sua qualidade, desafio e a forma como adiciona profundidade ao já rico mundo de Hollow Knight. Os fãs elogiaram especialmente a batalha contra o Nightmare King Grimm e a atmosfera única que a trupe traz ao jogo.
-Para jogadores que adoram desafios e estão interessados em explorar mais do lore de Hollow Knight, a Trupe do Grimm é uma adição imperdível ao jogo.</p>
-<br><br>
-</div>
-<div id="dov">
-<img src="images/Hollow knight DLC lifeblood.jpg">
-<br><br>
-</div>
-<div id="dov">
-<h3>Lançamento DLC "Sangue Vital</h3>
-</div>
-<div id="dov">
-<p>A DLC "Sangue Vital" (Lifeblood) é uma das atualizações gratuitas lançadas para Hollow Knight pela Team Cherry. Publicada em abril de 2018, esta expansão se concentra em melhorias de qualidade de vida, ajustes de jogabilidade, e algumas adições de conteúdo que refinam ainda mais a experiência de jogo. Vamos explorar os principais aspectos da DLC "Sangue Vital":</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Principais Recursos e Melhorias da DLC "Sangue Vital"</h3>
-</div>
-<div id="dov">
-<p>Novo Chefe - Enraged Guardian:Uma versão mais poderosa do chefe já existente, o Crystal Guardian. O Enraged Guardian é encontrado na mesma área (Crystallized Mound), mas oferece um desafio adicional com novos padrões de ataque e maior agressividade.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Nova Área Secreta - Hiveblood</h3>
-</div>
-<div id="dov">
- <p>Introduz a Hiveblood Room, um local secreto onde o jogador pode obter o amuleto Hiveblood. Este amuleto é particularmente útil, pois permite ao jogador regenerar lentamente um ponto de saúde perdido, desde que não sofra dano adicional.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Amuleto "Hiveblood"</h3>
-</div>
-<div id="dov">
- <p>Como mencionado, este amuleto regenera um ponto de saúde perdido após um curto período, desde que o jogador não sofra dano adicional nesse ínterim. Ele é especialmente útil para jogadores que preferem uma abordagem mais defensiva.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Alterações Visuais e Áudio</h3>
-</div>
-<div id="dov">
-<p>A DLC trouxe melhorias visuais significativas, incluindo ajustes no sistema de iluminação e efeitos gráficos aprimorados. Além disso, houve ajustes na trilha sonora e efeitos sonoros para melhorar a imersão do jogador.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Aprimoramentos de Interface</h3>
-</div>
-<div id="dov">
-<p>Melhorias na interface do usuário foram implementadas, como ajustes nos menus e melhorias no sistema de mapeamento, tornando mais fácil para os jogadores navegarem pelo mundo de Hallownest.</p>
-<br><br>
-</div>
-<div id="dov">
- <h3>Balancing e Ajustes de Jogo</h3>
-</div>
-<div id="dov">
-<p>Vários aspectos da jogabilidade foram refinados, incluindo ajustes no comportamento de inimigos, redistribuição de itens e ajustes de dificuldade em certos encontros para equilibrar a experiência de jogo.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Novo Conteúdo e Segredos</h3>
-</div>
-<div id="dov">
-<p>A DLC também incluiu novos segredos e conteúdo dispersos pelo mundo do jogo, incentivando os jogadores a explorar áreas anteriormente visitadas com novos olhos.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Impacto da DLC "Sangue Vital"</h3>
-</div>
-<div id="dov">
-<p>A  DLC "Sangue Vital" não introduziu uma quantidade massiva de novos conteúdos como outras DLCs de Hollow Knight, mas seu foco em refinamentos e melhorias de qualidade de vida foi amplamente apreciado pela comunidade. As alterações e otimizações feitas pela Team Cherry nesta atualização ajudaram a polir ainda mais um jogo já aclamado por sua profundidade e design cuidadoso.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Curiosidades</h3>
-</div>
-<div id="dov">
-<p>Desenvolvimento da Atualização: "Sangue Vital" foi a terceira das quatro grandes atualizações gratuitas planejadas pela Team Cherry para Hollow Knight. As outras são "Hidden Dreams", "The Grimm Troupe" e "Godmaster".</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Nome da DLC: O nome "Sangue Vital" reflete tanto o amuleto Hiveblood quanto a ideia de melhorias fundamentais e essenciais para a experiência de jogo</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Recepção pela Comunidade</h3>
-</div>
-<div id="dov">
-<p>Os jogadores elogiaram "Sangue Vital" por sua capacidade de melhorar o jogo base sem alterar drasticamente a experiência central. As melhorias de performance e as otimizações gráficas ajudaram a tornar o jogo mais acessível e fluido, especialmente para jogadores em plataformas diferentes. Além disso, o novo chefe e as áreas secretas adicionaram novos desafios e segredos, mantendo o espírito de exploração viva.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Conclusão</h3>
-</div>
-<div id="dov">
-<p>"Sangue Vital" é uma atualização que exemplifica o compromisso da Team Cherry com a melhoria contínua e a expansão do mundo de Hollow Knight. Mesmo sem adições gigantescas de conteúdo, ela contribuiu significativamente para a experiência geral do jogo, tornando-o ainda mais refinado e polido para os fãs e novos jogadores.</p>
-<br><br>
-</div>
-<div id="dov">
-<img src="images/Hollow knight sonhos escondidos grande.webp">
-<br><br>
-</div>
-<div id="dov">
-<h3>Lançamento da DLC "Sonhos escondidos"</h3>
-</div>
-<div id="dov">
-<p>A DLC "Dreams Escondidos" (Hidden Dreams) é uma das expansões gratuitas lançadas para Hollow Knight pela Team Cherry. Lançada em agosto de 2017, esta foi a primeira das quatro grandes atualizações planejadas para o jogo. A DLC adiciona novos chefes, novas mecânicas e alguns segredos interessantes que enriquecem a experiência de exploração em Hallownest. Vamos explorar os principais aspectos dessa atualização:</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Principais Recursos e Adições da DLC "Dreams Escondidos"</h3>
-</div>
-<div id="dov">
-<p>Novos Chefes dos Sonhos - "Warriors of Dream"</p>
-</div>
-<div id="dov">
-<p>White Defender: Uma versão dos sonhos de um dos chefes já existentes, o Dung Defender. Encontrado em um local secreto na Cidade das Lágrimas (City of Tears), o White Defender apresenta novos padrões de ataque e oferece uma batalha mais difícil e estilizada.</p>
-</div>
-<div id="dov">
-<p>Grey Prince Zote: Uma versão fantasiada e muito mais poderosa de Zote the Mighty, baseado nas histórias que Bretta imagina em sua mente. Ele é encontrado no Refúgio de Bretta (Bretta's Hut) após coletar uma certa quantidade de Essência. Este chefe é notório por sua imprevisibilidade e variedade de ataques.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Estações de Travessia - "Dream Gate"</h3>
-</div>
-<div id="dov">
-<p>Introduz a habilidade de criar Dream Gates, permitindo aos jogadores marcar pontos específicos no mundo de Hallownest e viajar rapidamente entre eles. Isso facilita a navegação e economiza tempo ao explorar áreas extensas ou retornar a locais anteriormente visitados.</p>
-<br><br>
-</div>
-<div id="dov">
- <h3>Novo Personagem - "The Godseeker"</h3>
-</div>
-<div id="dov">
-  <p>Esta DLC introduz o Godseeker, um personagem enigmático que desempenha um papel importante em uma das expansões posteriores, "Godmaster".
- O Godseeker oferece desafios adicionais e está relacionado ao aprofundamento do lore do jogo.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Salão dos Deuses</h3>
-</div>
-<div id="dov">
-<p>Um novo local chamado "Salão dos Deuses" foi adicionado. 
-Aqui, os jogadores podem enfrentar novamente chefes que já derrotaram no jogo principal, mas com um nível de dificuldade adicional. Esse local também apresenta desafios boss rush, onde você pode lutar contra vários chefes consecutivamente.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Estação da Mansão dos Pesadelos</h3>
-</div>
-<div id="dov">
- <p>Uma nova estação de viagem rápida, conhecida como "Estação da Mansão dos Pesadelos", foi adicionada. Isso facilita a movimentação pelo mundo do jogo e é especialmente útil para jogadores que buscam explorar cada canto do mapa.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Novas Melodias e Música</h3>
-</div>
-<div id="dov">
-<p>Christopher Larkin, o compositor do jogo, adicionou novas trilhas sonoras à DLC, aprimorando ainda mais a atmosfera rica e imersiva de "Hollow Knight".</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Novo Sistema de Diálogos</h3>
-</div>
-<div id="dov">
-<p>"Sonhos Escondidos" introduz novos diálogos e interações com NPCs, expandindo o lore e a história do jogo.</p>
-<br><br>
-</div>
-<div id="dov">
- <h3>Qualidade de Vida e Melhorias Gerais</h3>
-</div>
-<div id="dov">
-<p>A DLC também trouxe várias melhorias de qualidade de vida e balanceamentos no jogo, aprimorando a experiência geral para os jogadores.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Importância e Recepção</h3>
-</div>
-<div id="dov">
-<p>"Sonhos Escondidos" é uma das várias atualizações que a Team Cherry lançou para "Hollow Knight" sem custos adicionais, o que foi amplamente elogiado pela comunidade de jogadores. Essa expansão, em particular, foi apreciada por adicionar mais desafios e conteúdo para explorar, ao mesmo tempo em que enriquece a narrativa e o mundo do jogo.
-A abordagem da Team Cherry de fornecer conteúdo adicional gratuito foi vista como uma prática exemplar na indústria de jogos, solidificando a reputação de "Hollow Knight" como um dos melhores jogos indie de todos os tempos.</p>
-</div>
-<div id="dov">
-<img src="Images/Hollow knight DLC Godmaster grande.jpg">
-</div>
-<br><br>
-<div id="dov">
-<h3>Lançamento da DLC GODMASTER</h3>
-</div>
-<div id="dov">
-<p>A DLC "Godmaster" é a quarta e última grande atualização gratuita para "Hollow Knight", lançada pela Team Cherry em 23 de agosto de 2018. Ela adiciona uma quantidade significativa de novos conteúdos e desafios ao já extenso jogo, focando principalmente em combates intensos e oportunidades para os jogadores testarem suas habilidades contra os chefes mais poderosos do jogo.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Principais Características de "Godmaster"</h3>
-</div>
-<div id="dov">
-<p>Panteões dos Deuses</p>
-</div>
-<div id="dov">
-<p>A DLC introduz uma nova área chamada "Panteões dos Deuses", que é uma série de arenas onde os jogadores podem enfrentar chefes em sequência. Esses panteões são divididos em várias dificuldades, cada uma com uma série de lutas de chefes que se tornam progressivamente mais desafiadoras. Os panteões também incluem versões mais difíceis de chefes existentes, bem como alguns novos.
-Os panteões oferecem aos jogadores a chance de lutar contra todos os chefes em um único desafio contínuo, testando a resistência e a habilidade em combates prolongados.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Novos Chefes</h3>
-</div>
-<div id="dov">
-<p>"Godmaster" apresenta vários novos chefes, incluindo versões alternativas de chefes existentes e personagens completamente novos. Entre eles estão:</p>
-<br><br>
-</div>
-<div id="dov">
- <p>Sly: Um dos NPCs do jogo que revela suas habilidades escondidas como um mestre do combate.</p>
-</div>
-<br><br>
-</div>
-<div id="dov">
- <p>Pure Vessel: Uma versão purificada e ainda mais desafiadora do chefe Hollow Knight.</p>
-</div>
-<br><br>
-<div id="dov">
-<p>Absolute Radiance: Uma versão ainda mais poderosa do chefe final do jogo principal, a Radiance.</p>
- <br><br>
-</div>
-<div id="dov">
- <p>Painmaster Oro e Nailmaster Mato: Dois irmãos mestres do combate que se unem contra o jogador.
-Além desses, há versões "God Tamer" dos chefes, que são variantes mais difíceis encontradas nos Panteões.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Godseeker Mode</h3>
-</div>
-<div id="dov">
-<p>Um novo modo de jogo, chamado "Godseeker Mode", é desbloqueado após completar certos desafios nos Panteões.
- Esse modo oferece uma experiência focada nos combates com chefes, sem a necessidade de explorar o mundo inteiro do jogo.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Novos Encantos e Ferramentas</h3>
-</div>
-<div id="dov">
-<p>A DLC adiciona novos encantos e habilidades que os jogadores podem usar para enfrentar os desafios dos Panteões. 
-Entre esses estão encantos que modificam o estilo de jogo e novas combinações para os jogadores experimentarem.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Expansão da Trilha Sonora</h3>
-</div>
-<div id="dov">
-<p>Christopher Larkin, o compositor do jogo, adicionou novas músicas à trilha sonora para acompanhar as intensas batalhas dos Panteões, enriquecendo ainda mais a atmosfera épica de "Hollow Knight".</p>
-<br><br>
-</div>
-<div id="dov">
-<h3> História e Lore Expandido</h3>
-</div>
-<div id="dov">
-<p>A DLC "Godmaster" expande a narrativa do jogo, introduzindo novos personagens como o Godseeker e revelando mais sobre o passado e a mitologia do mundo de Hallownest. 
- Os jogadores podem descobrir mais sobre a história e os segredos dos deuses antigos ao explorar os Panteões e interagir com novos NPCs.</p>
-<br><br>
-</div>
-<div id="dov">
- <h3>Desafios Adicionais</h3>
-</div>
-<div id="dov">
- <p>"Godmaster" não só oferece novos chefes e lutas mais difíceis, mas também inclui desafios adicionais que testam a habilidade e a paciência dos jogadores, como modos de corrida contra o tempo e desafios boss rush.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Recepção e Impacto</h3>
-</div>
-<div id="dov">
-<p>"Godmaster" foi amplamente aclamada por adicionar um nível significativo de replay e desafio ao "Hollow Knight". A complexidade e a dificuldade dos novos conteúdos foram especialmente apreciadas por jogadores que buscavam testar seus limites após completarem o jogo principal. A expansão consolidou "Hollow Knight" como um título que recompensa a habilidade e a dedicação, com combates de chefes que são alguns dos mais memoráveis e exigentes da era moderna dos jogos indie.
-Essa DLC, junto com as outras atualizações gratuitas, reforçou a reputação da Team Cherry como um estúdio dedicado a oferecer valor incrível aos jogadores, elevando ainda mais o status de "Hollow Knight" como um clássico instantâneo na cena dos jogos independentes.</p>
-<br><br>
-</div>
-<div id="dov">
-<img src="images/Hollow-Knight novo-DLC-Pale-Cour.jpg">
- <br><br>
-</div>
-<div id="dov">
-<h3>Lançamento da DLC The Pale Court"</h3>
-</div>
-<div id="dov">
-<p>A última expansão notável para "Hollow Knight" chamada "O Palácio da Corte" não é, na verdade, uma DLC oficial desenvolvida pela Team Cherry, mas um mod criado por fãs, conhecido como "The Pale Court". 
- Esse modo foi lançado pela comunidade de modders de "Hollow Knight" em 1º de julho de 2023, trazendo novos desafios e conteúdos que poderiam facilmente ser confundidos com um lançamento oficial.</p>
-<br><br>
-</div>
-<div id="dov">
- <h3>Principais Características de "The Pale Court"</h3>
-</div>
-<div id="dov">
-<p> Foco nos Cinco Grandes Cavaleiros</p>
-</div>
-<div id="dov">
-<p>"The Pale Court" concentra-se nos Cinco Grandes Cavaleiros de Hallownest, figuras lendárias no lore de "Hollow Knight". 
-Cada um dos cavaleiros, exceto Ogrim (que já é um chefe no jogo base), é introduzido como um novo chefe no modo.
-Os jogadores podem enfrentar versões "sonhadas" desses cavaleiros, oferecendo um desafio adicional e expandindo a mitologia do jogo.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3> Novos Chefes</h3>
-</div>
-<div id="dov">
-<p>A DLC inclui chefes como</p>
-</div>
-<div id="dov">
-<p>Hegemol: Um dos grandes cavaleiros, com habilidades focadas em defesa e combate corpo a corpo.</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Isma: Conhecida por sua conexão com a natureza e habilidades baseadas em veneno e proteção.</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Dryya: Um cavaleiro feroz com habilidades de combate rápidas e poderosas.</p>
-<br><br>
-</div>
-<div id="dov">
-<p>Zemir: Possui habilidades misteriosas e de controle de multidões.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Novos Encantos e Ferramentas</h3>
-</div>
-<div id="dov">
-<p>"The Pale Court" introduz novos encantos que podem ser equipados para modificar e melhorar as habilidades do Cavaleiro. 
-Esses encantos adicionam novas formas de jogo e estratégias para enfrentar os desafios dos novos chefes.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Expansão da História e do Lore</h3>
-</div>
-<div id="dov">
-<p>A expansão aprofunda o lore de Hallownest, oferecendo mais contexto e detalhes sobre os Cinco Grandes Cavaleiros e seus papéis no reino. 
-Isso é feito através de novos diálogos, entradas no diário e interações com NPCs.</p>
- <br><br>
-</div>
-<div id="dov">
-<h3>Desafios e Conteúdo Adicional</h3>
-</div>
-<div id="dov">
-<p>A DLC adiciona novos desafios de plataforma e combate, incluindo áreas difíceis que testam as habilidades de navegação dos jogadores. 
-Os desafios são projetados para jogadores que já dominam os elementos básicos do jogo e estão procurando por conteúdo mais exigente.</p>
- <br><br>
-</div>
-<div id="dov">
- <h3>Melhorias e Recursos Visuais</h3>
-</div>
-<div id="dov">
-<p>O mod também traz melhorias visuais, com novos cenários e designs de chefe que se integram perfeitamente ao estilo artístico de "Hollow Knight".
- A estética do "Pale Court" é detalhada e consistente com a atmosfera sombria e cativante do jogo original.</p>
-<br><br>
-</div>
-<div id="dov">
-<h3>Recepção e Importância</h3>
-</div>
-<div id="dov">
-<p>"The Pale Court" recebeu aclamação tanto da comunidade de jogadores quanto de críticos por sua qualidade e fidelidade ao espírito de "Hollow Knight". 
-Muitos jogadores elogiaram o mod pela forma como expande e aprofunda a experiência de jogo, oferecendo novos desafios e explorando mais do rico universo de Hallownest.
-A criação de "The Pale Court" demonstra a paixão e a criatividade da comunidade de "Hollow Knight", que continua a manter o jogo vivo e relevante, mesmo anos após seu lançamento original. 
-Esse mod mostra como os fãs podem contribuir significativamente para o legado de um jogo, adicionando conteúdo que complementa e enriquece a experiência dos jogadores.</p>
-</div>
-                
+                    <div id="dov">
+                        <h3>Novos Personagens</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Grimm: O líder enigmático da trupe, que guia o Cavaleiro em uma missão peculiar.
+                            <br><br>
+                    </div>
+                    <div id="dov">
+                        Brumm: Um membro da trupe que toca o acordeão e oferece pistas e segredos ao jogador.
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        Baboons: Pequenos seguidores da trupe, com comportamentos estranhos e divertidos.
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        Divine: Uma figura feminina da trupe que se instala na vila e oferece melhorias para os amuletos
+                        do jogador.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novos Chefes</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Grimm: Enfrentado em diferentes formas e dificuldades, ele testa as habilidades do jogador
+                            com movimentos rápidos e ataques de fogo.
+                            <br><br>
+                    </div>
+                    <div id="dov">
+                        Nightmare King Grimm: Uma versão ainda mais poderosa de Grimm, este chefe é notório por sua
+                        dificuldade extrema e padrões de ataque complexos.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novos Amuletos</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC introduz novos amuletos que o jogador pode equipar para ganhar habilidades especiais:
+                        </p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Amuleto do Grimmchild: Concede um familiar que ajuda em combate, evoluindo conforme o jogador
+                            coleta as chamas.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Amuletos de Confraria: Opções adicionais oferecidas pela Trupe do Grimm, modificando e
+                            melhorando as habilidades do jogador de formas únicas.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Elementos Adicionais</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Conteúdo de História: A DLC expande o lore do mundo de Hollow Knight, oferecendo mais
+                            detalhes sobre a misteriosa trupe e sua conexão com Hallownest.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Novos Desafios e Inimigos: Além dos novos chefes, a DLC adiciona novos tipos de inimigos e
+                            desafios para os jogadores superarem.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Múltiplos Finais: Dependendo das escolhas do jogador ao longo da missão, diferentes desfechos
+                            podem ser alcançados, oferecendo rejogabilidade e variação na narrativa.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Atmosfera e Arte</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A Trupe do Grimm traz uma estética única ao jogo, com sua temática circense sombria e trilha
+                            sonora evocativa, composta por Christopher Larkin. A arte e o design de som complementam
+                            perfeitamente a sensação misteriosa e encantadora que a DLC busca transmitir.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Impacto e Recepção</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC da Trupe do Grimm foi amplamente aclamada por sua qualidade, desafio e a forma como
+                            adiciona profundidade ao já rico mundo de Hollow Knight. Os fãs elogiaram especialmente a
+                            batalha contra o Nightmare King Grimm e a atmosfera única que a trupe traz ao jogo.
+                            Para jogadores que adoram desafios e estão interessados em explorar mais do lore de Hollow
+                            Knight, a Trupe do Grimm é uma adição imperdível ao jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <img src="images/Hollow knight DLC lifeblood.jpg">
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Lançamento DLC "Sangue Vital</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC "Sangue Vital" (Lifeblood) é uma das atualizações gratuitas lançadas para Hollow Knight
+                            pela Team Cherry. Publicada em abril de 2018, esta expansão se concentra em melhorias de
+                            qualidade de vida, ajustes de jogabilidade, e algumas adições de conteúdo que refinam ainda
+                            mais a experiência de jogo. Vamos explorar os principais aspectos da DLC "Sangue Vital":</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Principais Recursos e Melhorias da DLC "Sangue Vital"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Novo Chefe - Enraged Guardian:Uma versão mais poderosa do chefe já existente, o Crystal
+                            Guardian. O Enraged Guardian é encontrado na mesma área (Crystallized Mound), mas oferece um
+                            desafio adicional com novos padrões de ataque e maior agressividade.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Nova Área Secreta - Hiveblood</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Introduz a Hiveblood Room, um local secreto onde o jogador pode obter o amuleto Hiveblood.
+                            Este amuleto é particularmente útil, pois permite ao jogador regenerar lentamente um ponto
+                            de saúde perdido, desde que não sofra dano adicional.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Amuleto "Hiveblood"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Como mencionado, este amuleto regenera um ponto de saúde perdido após um curto período, desde
+                            que o jogador não sofra dano adicional nesse ínterim. Ele é especialmente útil para
+                            jogadores que preferem uma abordagem mais defensiva.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Alterações Visuais e Áudio</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC trouxe melhorias visuais significativas, incluindo ajustes no sistema de iluminação e
+                            efeitos gráficos aprimorados. Além disso, houve ajustes na trilha sonora e efeitos sonoros
+                            para melhorar a imersão do jogador.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Aprimoramentos de Interface</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Melhorias na interface do usuário foram implementadas, como ajustes nos menus e melhorias no
+                            sistema de mapeamento, tornando mais fácil para os jogadores navegarem pelo mundo de
+                            Hallownest.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Balancing e Ajustes de Jogo</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Vários aspectos da jogabilidade foram refinados, incluindo ajustes no comportamento de
+                            inimigos, redistribuição de itens e ajustes de dificuldade em certos encontros para
+                            equilibrar a experiência de jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novo Conteúdo e Segredos</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC também incluiu novos segredos e conteúdo dispersos pelo mundo do jogo, incentivando os
+                            jogadores a explorar áreas anteriormente visitadas com novos olhos.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Impacto da DLC "Sangue Vital"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC "Sangue Vital" não introduziu uma quantidade massiva de novos conteúdos como outras
+                            DLCs de Hollow Knight, mas seu foco em refinamentos e melhorias de qualidade de vida foi
+                            amplamente apreciado pela comunidade. As alterações e otimizações feitas pela Team Cherry
+                            nesta atualização ajudaram a polir ainda mais um jogo já aclamado por sua profundidade e
+                            design cuidadoso.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Curiosidades</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Desenvolvimento da Atualização: "Sangue Vital" foi a terceira das quatro grandes atualizações
+                            gratuitas planejadas pela Team Cherry para Hollow Knight. As outras são "Hidden Dreams",
+                            "The Grimm Troupe" e "Godmaster".</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Nome da DLC: O nome "Sangue Vital" reflete tanto o amuleto Hiveblood quanto a ideia de
+                            melhorias fundamentais e essenciais para a experiência de jogo</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Recepção pela Comunidade</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Os jogadores elogiaram "Sangue Vital" por sua capacidade de melhorar o jogo base sem alterar
+                            drasticamente a experiência central. As melhorias de performance e as otimizações gráficas
+                            ajudaram a tornar o jogo mais acessível e fluido, especialmente para jogadores em
+                            plataformas diferentes. Além disso, o novo chefe e as áreas secretas adicionaram novos
+                            desafios e segredos, mantendo o espírito de exploração viva.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Conclusão</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Sangue Vital" é uma atualização que exemplifica o compromisso da Team Cherry com a melhoria
+                            contínua e a expansão do mundo de Hollow Knight. Mesmo sem adições gigantescas de conteúdo,
+                            ela contribuiu significativamente para a experiência geral do jogo, tornando-o ainda mais
+                            refinado e polido para os fãs e novos jogadores.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <img src="images/Hollow knight sonhos escondidos grande.webp">
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Lançamento da DLC "Sonhos escondidos"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC "Dreams Escondidos" (Hidden Dreams) é uma das expansões gratuitas lançadas para Hollow
+                            Knight pela Team Cherry. Lançada em agosto de 2017, esta foi a primeira das quatro grandes
+                            atualizações planejadas para o jogo. A DLC adiciona novos chefes, novas mecânicas e alguns
+                            segredos interessantes que enriquecem a experiência de exploração em Hallownest. Vamos
+                            explorar os principais aspectos dessa atualização:</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Principais Recursos e Adições da DLC "Dreams Escondidos"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Novos Chefes dos Sonhos - "Warriors of Dream"</p>
+                    </div>
+                    <div id="dov">
+                        <p>White Defender: Uma versão dos sonhos de um dos chefes já existentes, o Dung Defender.
+                            Encontrado em um local secreto na Cidade das Lágrimas (City of Tears), o White Defender
+                            apresenta novos padrões de ataque e oferece uma batalha mais difícil e estilizada.</p>
+                    </div>
+                    <div id="dov">
+                        <p>Grey Prince Zote: Uma versão fantasiada e muito mais poderosa de Zote the Mighty, baseado nas
+                            histórias que Bretta imagina em sua mente. Ele é encontrado no Refúgio de Bretta (Bretta's
+                            Hut) após coletar uma certa quantidade de Essência. Este chefe é notório por sua
+                            imprevisibilidade e variedade de ataques.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Estações de Travessia - "Dream Gate"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Introduz a habilidade de criar Dream Gates, permitindo aos jogadores marcar pontos
+                            específicos no mundo de Hallownest e viajar rapidamente entre eles. Isso facilita a
+                            navegação e economiza tempo ao explorar áreas extensas ou retornar a locais anteriormente
+                            visitados.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novo Personagem - "The Godseeker"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Esta DLC introduz o Godseeker, um personagem enigmático que desempenha um papel importante em
+                            uma das expansões posteriores, "Godmaster".
+                            O Godseeker oferece desafios adicionais e está relacionado ao aprofundamento do lore do
+                            jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Salão dos Deuses</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Um novo local chamado "Salão dos Deuses" foi adicionado.
+                            Aqui, os jogadores podem enfrentar novamente chefes que já derrotaram no jogo principal, mas
+                            com um nível de dificuldade adicional. Esse local também apresenta desafios boss rush, onde
+                            você pode lutar contra vários chefes consecutivamente.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Estação da Mansão dos Pesadelos</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Uma nova estação de viagem rápida, conhecida como "Estação da Mansão dos Pesadelos", foi
+                            adicionada. Isso facilita a movimentação pelo mundo do jogo e é especialmente útil para
+                            jogadores que buscam explorar cada canto do mapa.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novas Melodias e Música</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Christopher Larkin, o compositor do jogo, adicionou novas trilhas sonoras à DLC, aprimorando
+                            ainda mais a atmosfera rica e imersiva de "Hollow Knight".</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novo Sistema de Diálogos</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Sonhos Escondidos" introduz novos diálogos e interações com NPCs, expandindo o lore e a
+                            história do jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Qualidade de Vida e Melhorias Gerais</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC também trouxe várias melhorias de qualidade de vida e balanceamentos no jogo,
+                            aprimorando a experiência geral para os jogadores.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Importância e Recepção</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Sonhos Escondidos" é uma das várias atualizações que a Team Cherry lançou para "Hollow
+                            Knight" sem custos adicionais, o que foi amplamente elogiado pela comunidade de jogadores.
+                            Essa expansão, em particular, foi apreciada por adicionar mais desafios e conteúdo para
+                            explorar, ao mesmo tempo em que enriquece a narrativa e o mundo do jogo.
+                            A abordagem da Team Cherry de fornecer conteúdo adicional gratuito foi vista como uma
+                            prática exemplar na indústria de jogos, solidificando a reputação de "Hollow Knight" como um
+                            dos melhores jogos indie de todos os tempos.</p>
+                    </div>
+                    <div id="dov">
+                        <img src="Images/Hollow knight DLC Godmaster grande.jpg">
+                    </div>
+                    <br><br>
+                    <div id="dov">
+                        <h3>Lançamento da DLC GODMASTER</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC "Godmaster" é a quarta e última grande atualização gratuita para "Hollow Knight",
+                            lançada pela Team Cherry em 23 de agosto de 2018. Ela adiciona uma quantidade significativa
+                            de novos conteúdos e desafios ao já extenso jogo, focando principalmente em combates
+                            intensos e oportunidades para os jogadores testarem suas habilidades contra os chefes mais
+                            poderosos do jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Principais Características de "Godmaster"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Panteões dos Deuses</p>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC introduz uma nova área chamada "Panteões dos Deuses", que é uma série de arenas onde os
+                            jogadores podem enfrentar chefes em sequência. Esses panteões são divididos em várias
+                            dificuldades, cada uma com uma série de lutas de chefes que se tornam progressivamente mais
+                            desafiadoras. Os panteões também incluem versões mais difíceis de chefes existentes, bem
+                            como alguns novos.
+                            Os panteões oferecem aos jogadores a chance de lutar contra todos os chefes em um único
+                            desafio contínuo, testando a resistência e a habilidade em combates prolongados.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novos Chefes</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Godmaster" apresenta vários novos chefes, incluindo versões alternativas de chefes
+                            existentes e personagens completamente novos. Entre eles estão:</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Sly: Um dos NPCs do jogo que revela suas habilidades escondidas como um mestre do combate.
+                        </p>
+                    </div>
+                    <br><br>
+                    <div id="dov">
+                        <p>Pure Vessel: Uma versão purificada e ainda mais desafiadora do chefe Hollow Knight.</p>
+                    </div>
+                    <br><br>
+                    <div id="dov">
+                        <p>Absolute Radiance: Uma versão ainda mais poderosa do chefe final do jogo principal, a Radiance.
+                        </p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Painmaster Oro e Nailmaster Mato: Dois irmãos mestres do combate que se unem contra o jogador.
+                            Além desses, há versões "God Tamer" dos chefes, que são variantes mais difíceis encontradas nos
+                            Panteões.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Godseeker Mode</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Um novo modo de jogo, chamado "Godseeker Mode", é desbloqueado após completar certos desafios nos
+                            Panteões.
+                            Esse modo oferece uma experiência focada nos combates com chefes, sem a necessidade de explorar
+                            o mundo inteiro do jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novos Encantos e Ferramentas</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC adiciona novos encantos e habilidades que os jogadores podem usar para enfrentar os
+                            desafios dos Panteões.
+                            Entre esses estão encantos que modificam o estilo de jogo e novas combinações para os jogadores
+                            experimentarem.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Expansão da Trilha Sonora</h3>
+                    </div>
+                    <div id="dov">
+                        <p>Christopher Larkin, o compositor do jogo, adicionou novas músicas à trilha sonora para acompanhar
+                            as intensas batalhas dos Panteões, enriquecendo ainda mais a atmosfera épica de "Hollow Knight".
+                        </p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3> História e Lore Expandido</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC "Godmaster" expande a narrativa do jogo, introduzindo novos personagens como o Godseeker e
+                            revelando mais sobre o passado e a mitologia do mundo de Hallownest.
+                            Os jogadores podem descobrir mais sobre a história e os segredos dos deuses antigos ao explorar
+                            os Panteões e interagir com novos NPCs.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Desafios Adicionais</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Godmaster" não só oferece novos chefes e lutas mais difíceis, mas também inclui desafios
+                            adicionais que testam a habilidade e a paciência dos jogadores, como modos de corrida contra o
+                            tempo e desafios boss rush.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Recepção e Impacto</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"Godmaster" foi amplamente aclamada por adicionar um nível significativo de replay e desafio ao
+                            "Hollow Knight". A complexidade e a dificuldade dos novos conteúdos foram especialmente
+                            apreciadas por jogadores que buscavam testar seus limites após completarem o jogo principal. A
+                            expansão consolidou "Hollow Knight" como um título que recompensa a habilidade e a dedicação,
+                            com combates de chefes que são alguns dos mais memoráveis e exigentes da era moderna dos jogos
+                            indie.
+                            Essa DLC, junto com as outras atualizações gratuitas, reforçou a reputação da Team Cherry como
+                            um estúdio dedicado a oferecer valor incrível aos jogadores, elevando ainda mais o status de
+                            "Hollow Knight" como um clássico instantâneo na cena dos jogos independentes.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <img src="images/Hollow-Knight novo-DLC-Pale-Cour.jpg">
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Lançamento da DLC The Pale Court"</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A última expansão notável para "Hollow Knight" chamada "O Palácio da Corte" não é, na verdade,
+                            uma DLC oficial desenvolvida pela Team Cherry, mas um mod criado por fãs, conhecido como "The
+                            Pale Court".
+                            Esse modo foi lançado pela comunidade de modders de "Hollow Knight" em 1º de julho de 2023,
+                            trazendo novos desafios e conteúdos que poderiam facilmente ser confundidos com um lançamento
+                            oficial.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Principais Características de "The Pale Court"</h3>
+                    </div>
+                    <div id="dov">
+                        <p> Foco nos Cinco Grandes Cavaleiros</p>
+                    </div>
+                    <div id="dov">
+                        <p>"The Pale Court" concentra-se nos Cinco Grandes Cavaleiros de Hallownest, figuras lendárias no
+                            lore de "Hollow Knight".
+                            Cada um dos cavaleiros, exceto Ogrim (que já é um chefe no jogo base), é introduzido como um
+                            novo chefe no modo.
+                            Os jogadores podem enfrentar versões "sonhadas" desses cavaleiros, oferecendo um desafio
+                            adicional e expandindo a mitologia do jogo.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3> Novos Chefes</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC inclui chefes como</p>
+                    </div>
+                    <div id="dov">
+                        <p>Hegemol: Um dos grandes cavaleiros, com habilidades focadas em defesa e combate corpo a corpo.
+                        </p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Isma: Conhecida por sua conexão com a natureza e habilidades baseadas em veneno e proteção.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Dryya: Um cavaleiro feroz com habilidades de combate rápidas e poderosas.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <p>Zemir: Possui habilidades misteriosas e de controle de multidões.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Novos Encantos e Ferramentas</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"The Pale Court" introduz novos encantos que podem ser equipados para modificar e melhorar as
+                            habilidades do Cavaleiro.
+                            Esses encantos adicionam novas formas de jogo e estratégias para enfrentar os desafios dos novos
+                            chefes.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Expansão da História e do Lore</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A expansão aprofunda o lore de Hallownest, oferecendo mais contexto e detalhes sobre os Cinco
+                            Grandes Cavaleiros e seus papéis no reino.
+                            Isso é feito através de novos diálogos, entradas no diário e interações com NPCs.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Desafios e Conteúdo Adicional</h3>
+                    </div>
+                    <div id="dov">
+                        <p>A DLC adiciona novos desafios de plataforma e combate, incluindo áreas difíceis que testam as
+                            habilidades de navegação dos jogadores.
+                            Os desafios são projetados para jogadores que já dominam os elementos básicos do jogo e estão
+                            procurando por conteúdo mais exigente.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Melhorias e Recursos Visuais</h3>
+                    </div>
+                    <div id="dov">
+                        <p>O mod também traz melhorias visuais, com novos cenários e designs de chefe que se integram
+                            perfeitamente ao estilo artístico de "Hollow Knight".
+                            A estética do "Pale Court" é detalhada e consistente com a atmosfera sombria e cativante do jogo
+                            original.</p>
+                        <br><br>
+                    </div>
+                    <div id="dov">
+                        <h3>Recepção e Importância</h3>
+                    </div>
+                    <div id="dov">
+                        <p>"The Pale Court" recebeu aclamação tanto da comunidade de jogadores quanto de críticos por sua
+                            qualidade e fidelidade ao espírito de "Hollow Knight".
+                            Muitos jogadores elogiaram o mod pela forma como expande e aprofunda a experiência de jogo,
+                            oferecendo novos desafios e explorando mais do rico universo de Hallownest.
+                            A criação de "The Pale Court" demonstra a paixão e a criatividade da comunidade de "Hollow
+                            Knight", que continua a manter o jogo vivo e relevante, mesmo anos após seu lançamento original.
+                            Esse mod mostra como os fãs podem contribuir significativamente para o legado de um jogo,
+                            adicionando conteúdo que complementa e enriquece a experiência dos jogadores.</p>
+                    </div>
+                </div>
 
 
 
@@ -511,18 +654,21 @@ Esse mod mostra como os fãs podem contribuir significativamente para o legado d
 
 
 
-              
-                
-                
-                
 
 
 
 
 
-       
-</head>
-<body>
-    
-</body>
+
+
+
+
+
+
+    </head>
+
+    <body>
+
+    </body>
+
 </html>

--- a/as DLCs.html
+++ b/as DLCs.html
@@ -1,670 +1,635 @@
 <!DOCTYPE html>
 <html lang="pt-br">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>as DLCs</title>
-    <link rel="stylesheet" href="style.css">
-</head>
+    <link rel="stylesheet" href="style.css" />
+  </head>
 
-<body>
+  <body>
     <header>
-        <div id="title">
-            <h1>as DLCs</h1>
-        </div>
+      <div id="title">
+        <h1>as DLCs</h1>
+      </div>
 
-        <ul>
-            <a href="https://www.youtube.com/watch?v=E4eoHLskxwE&t=3s" id="Desenvolvimento-btn">
-                <li>Desenvolvimento</li>
-            </a>
-            <a href="https://www.youtube.com/watch?v=ItQoBbQGMvY&t=223s" id="História-btn">
-                <li>Historia</li>
-            </a>
-            <a href="Empresa.html">
-                <li>Empresa</li>
-            </a>
-            <a href="jogo.html">
-                <li>O jogo</li>
-            </a>
-            <a href="as DLCs.html">
-                <li>as DLCs</li>
-            </a>
-            <a href="Lancamentos.html">
-                <li> Lancamentos</li>
-            </a>
-            <a href="https://www.youtube.com/watch?v=nZtDYuzMR1E&t=32s" id="Curiosidades-btn">
-                <li>Curiosidades</li>
-            </a>
-            <a href="https://store.steampowered.com/app/367520/Hollow_Knight/" id="Onde comprar- btn">
-                <li>Onde comprar?</li>
-            </a>
-
-
-
-        </ul>
+      <ul>
+        <a href="https://www.youtube.com/watch?v=E4eoHLskxwE&t=3s" id="Desenvolvimento-btn">
+          <li>Desenvolvimento</li>
+        </a>
+        <a href="https://www.youtube.com/watch?v=ItQoBbQGMvY&t=223s" id="História-btn">
+          <li>Historia</li>
+        </a>
+        <a href="Empresa.html">
+          <li>Empresa</li>
+        </a>
+        <a href="jogo.html">
+          <li>O jogo</li>
+        </a>
+        <a href="as DLCs.html">
+          <li>as DLCs</li>
+        </a>
+        <a href="Lancamentos.html">
+          <li>Lancamentos</li>
+        </a>
+        <a href="https://www.youtube.com/watch?v=nZtDYuzMR1E&t=32s" id="Curiosidades-btn">
+          <li>Curiosidades</li>
+        </a>
+        <a href="https://store.steampowered.com/app/367520/Hollow_Knight/" id="Onde comprar- btn">
+          <li>Onde comprar?</li>
+        </a>
+      </ul>
     </header>
 
-    <head>
-        <!-----as DLCs-->
-        <section class="as DLCs" id="as DLCs">
-            <div class="container">
-                <div class="center">
-                    <h2>As DLCs do game</h2>
-                    <div id="dov">
-                        <img src="images/Hollow knight DLC Grimm troupe grande.jpg">
-                        <br><br>
-                    </div>
+    <!-----as DLCs-->
+    <section class="as DLCs" id="as DLCs">
+      <div class="container">
+        <div class="center">
+          <h2>As DLCs do game</h2>
+          <div id="dov">
+            <img src="images/Hollow knight DLC Grimm troupe grande.jpg" />
+            <br /><br />
+          </div>
 
-                    <div id="dov">
-                        <h3>Lançamento da DLC "Tropa do Grimm"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC “Grimm Troupe” de Hollow Knight é uma das expansões gratuitas mais populares do jogo,
-                            lançada em outubro de 2017.
-                            Esta atualização trouxe uma nova narrativa, personagens, desafios e melhorias significativas
-                            ao jogo base.
-                            Vamos explorar os detalhes dessa expansão fascinante.</p>
-                        <br><br>
-                    </div>
-                    <br><br>
+          <div id="dov">
+            <h3>Lançamento da DLC "Tropa do Grimm"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC “Grimm Troupe” de Hollow Knight é uma das expansões gratuitas mais populares do jogo, lançada em outubro de 2017. Esta atualização trouxe uma nova narrativa, personagens, desafios
+              e melhorias significativas ao jogo base. Vamos explorar os detalhes dessa expansão fascinante.
+            </p>
+            <br /><br />
+          </div>
+          <br /><br />
 
-                    <div id="dov">
-                        <h3>O Que é a “Grimm Troupe”?</h3>
-                    </div>
-                    <div id="dov">
-                        <p>“The Grimm Troupe” é uma expansão que introduz uma nova missão centrada em torno de uma trupe
-                            de circo itinerante liderada pelo misterioso Mestre Grimm.
-                            A trupe chega a Hallownest e desencadeia uma série de eventos que envolvem o jogador em uma
-                            história sombria e enigmática.</p>
-                        <br><br>
-                    </div>
+          <div id="dov">
+            <h3>O Que é a “Grimm Troupe”?</h3>
+          </div>
+          <div id="dov">
+            <p>
+              “The Grimm Troupe” é uma expansão que introduz uma nova missão centrada em torno de uma trupe de circo itinerante liderada pelo misterioso Mestre Grimm. A trupe chega a Hallownest e
+              desencadeia uma série de eventos que envolvem o jogador em uma história sombria e enigmática.
+            </p>
+            <br /><br />
+          </div>
 
-                    <div id="dov">
-                        <h3>Principais Adições da DLC “Grimm Troupe"</h3>
-                    </div>
-                    <br><br>
-                    <div id="dov">
-                        <h3>Narrativa e Missões</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Convocação da Troupe: O jogador inicia a DLC ao encontrar e acender a "Lanterna do Pesadelo"
-                            em uma nova área do Reino Esquecido (Forgotten Crossroads).
-                            Isso convoca a Troupe Grimm para Hallownest.</p>
-                    </div>
-                    <div id="dov">
-                        <p>O Mestre Grimm: Após convocar a trupe, o jogador conhece o Mestre Grimm, que lhes confia a
-                            tarefa de coletar “Flamas de Pesadelo” (Nightmare Flames) espalhadas pelo reino.
-                            Essas chamas são essenciais para completar o ritual da trupe.</p>
-                        <br><br>
-                    </div>
+          <div id="dov">
+            <h3>Principais Adições da DLC “Grimm Troupe"</h3>
+          </div>
+          <br /><br />
+          <div id="dov">
+            <h3>Narrativa e Missões</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Convocação da Troupe: O jogador inicia a DLC ao encontrar e acender a "Lanterna do Pesadelo" em uma nova área do Reino Esquecido (Forgotten Crossroads). Isso convoca a Troupe Grimm para
+              Hallownest.
+            </p>
+          </div>
+          <div id="dov">
+            <p>
+              O Mestre Grimm: Após convocar a trupe, o jogador conhece o Mestre Grimm, que lhes confia a tarefa de coletar “Flamas de Pesadelo” (Nightmare Flames) espalhadas pelo reino. Essas chamas
+              são essenciais para completar o ritual da trupe.
+            </p>
+            <br /><br />
+          </div>
 
-                    <div id="dov">
-                        <h3>Novos Personagens</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Grimm: O líder enigmático da trupe, que guia o Cavaleiro em uma missão peculiar.
-                            <br><br>
-                    </div>
-                    <div id="dov">
-                        Brumm: Um membro da trupe que toca o acordeão e oferece pistas e segredos ao jogador.
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        Baboons: Pequenos seguidores da trupe, com comportamentos estranhos e divertidos.
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        Divine: Uma figura feminina da trupe que se instala na vila e oferece melhorias para os amuletos
-                        do jogador.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novos Chefes</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Grimm: Enfrentado em diferentes formas e dificuldades, ele testa as habilidades do jogador
-                            com movimentos rápidos e ataques de fogo.
-                            <br><br>
-                    </div>
-                    <div id="dov">
-                        Nightmare King Grimm: Uma versão ainda mais poderosa de Grimm, este chefe é notório por sua
-                        dificuldade extrema e padrões de ataque complexos.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novos Amuletos</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC introduz novos amuletos que o jogador pode equipar para ganhar habilidades especiais:
-                        </p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Amuleto do Grimmchild: Concede um familiar que ajuda em combate, evoluindo conforme o jogador
-                            coleta as chamas.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Amuletos de Confraria: Opções adicionais oferecidas pela Trupe do Grimm, modificando e
-                            melhorando as habilidades do jogador de formas únicas.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Elementos Adicionais</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Conteúdo de História: A DLC expande o lore do mundo de Hollow Knight, oferecendo mais
-                            detalhes sobre a misteriosa trupe e sua conexão com Hallownest.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Novos Desafios e Inimigos: Além dos novos chefes, a DLC adiciona novos tipos de inimigos e
-                            desafios para os jogadores superarem.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Múltiplos Finais: Dependendo das escolhas do jogador ao longo da missão, diferentes desfechos
-                            podem ser alcançados, oferecendo rejogabilidade e variação na narrativa.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Atmosfera e Arte</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A Trupe do Grimm traz uma estética única ao jogo, com sua temática circense sombria e trilha
-                            sonora evocativa, composta por Christopher Larkin. A arte e o design de som complementam
-                            perfeitamente a sensação misteriosa e encantadora que a DLC busca transmitir.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Impacto e Recepção</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC da Trupe do Grimm foi amplamente aclamada por sua qualidade, desafio e a forma como
-                            adiciona profundidade ao já rico mundo de Hollow Knight. Os fãs elogiaram especialmente a
-                            batalha contra o Nightmare King Grimm e a atmosfera única que a trupe traz ao jogo.
-                            Para jogadores que adoram desafios e estão interessados em explorar mais do lore de Hollow
-                            Knight, a Trupe do Grimm é uma adição imperdível ao jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <img src="images/Hollow knight DLC lifeblood.jpg">
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Lançamento DLC "Sangue Vital</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC "Sangue Vital" (Lifeblood) é uma das atualizações gratuitas lançadas para Hollow Knight
-                            pela Team Cherry. Publicada em abril de 2018, esta expansão se concentra em melhorias de
-                            qualidade de vida, ajustes de jogabilidade, e algumas adições de conteúdo que refinam ainda
-                            mais a experiência de jogo. Vamos explorar os principais aspectos da DLC "Sangue Vital":</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Principais Recursos e Melhorias da DLC "Sangue Vital"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Novo Chefe - Enraged Guardian:Uma versão mais poderosa do chefe já existente, o Crystal
-                            Guardian. O Enraged Guardian é encontrado na mesma área (Crystallized Mound), mas oferece um
-                            desafio adicional com novos padrões de ataque e maior agressividade.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Nova Área Secreta - Hiveblood</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Introduz a Hiveblood Room, um local secreto onde o jogador pode obter o amuleto Hiveblood.
-                            Este amuleto é particularmente útil, pois permite ao jogador regenerar lentamente um ponto
-                            de saúde perdido, desde que não sofra dano adicional.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Amuleto "Hiveblood"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Como mencionado, este amuleto regenera um ponto de saúde perdido após um curto período, desde
-                            que o jogador não sofra dano adicional nesse ínterim. Ele é especialmente útil para
-                            jogadores que preferem uma abordagem mais defensiva.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Alterações Visuais e Áudio</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC trouxe melhorias visuais significativas, incluindo ajustes no sistema de iluminação e
-                            efeitos gráficos aprimorados. Além disso, houve ajustes na trilha sonora e efeitos sonoros
-                            para melhorar a imersão do jogador.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Aprimoramentos de Interface</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Melhorias na interface do usuário foram implementadas, como ajustes nos menus e melhorias no
-                            sistema de mapeamento, tornando mais fácil para os jogadores navegarem pelo mundo de
-                            Hallownest.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Balancing e Ajustes de Jogo</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Vários aspectos da jogabilidade foram refinados, incluindo ajustes no comportamento de
-                            inimigos, redistribuição de itens e ajustes de dificuldade em certos encontros para
-                            equilibrar a experiência de jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novo Conteúdo e Segredos</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC também incluiu novos segredos e conteúdo dispersos pelo mundo do jogo, incentivando os
-                            jogadores a explorar áreas anteriormente visitadas com novos olhos.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Impacto da DLC "Sangue Vital"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC "Sangue Vital" não introduziu uma quantidade massiva de novos conteúdos como outras
-                            DLCs de Hollow Knight, mas seu foco em refinamentos e melhorias de qualidade de vida foi
-                            amplamente apreciado pela comunidade. As alterações e otimizações feitas pela Team Cherry
-                            nesta atualização ajudaram a polir ainda mais um jogo já aclamado por sua profundidade e
-                            design cuidadoso.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Curiosidades</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Desenvolvimento da Atualização: "Sangue Vital" foi a terceira das quatro grandes atualizações
-                            gratuitas planejadas pela Team Cherry para Hollow Knight. As outras são "Hidden Dreams",
-                            "The Grimm Troupe" e "Godmaster".</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Nome da DLC: O nome "Sangue Vital" reflete tanto o amuleto Hiveblood quanto a ideia de
-                            melhorias fundamentais e essenciais para a experiência de jogo</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Recepção pela Comunidade</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Os jogadores elogiaram "Sangue Vital" por sua capacidade de melhorar o jogo base sem alterar
-                            drasticamente a experiência central. As melhorias de performance e as otimizações gráficas
-                            ajudaram a tornar o jogo mais acessível e fluido, especialmente para jogadores em
-                            plataformas diferentes. Além disso, o novo chefe e as áreas secretas adicionaram novos
-                            desafios e segredos, mantendo o espírito de exploração viva.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Conclusão</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Sangue Vital" é uma atualização que exemplifica o compromisso da Team Cherry com a melhoria
-                            contínua e a expansão do mundo de Hollow Knight. Mesmo sem adições gigantescas de conteúdo,
-                            ela contribuiu significativamente para a experiência geral do jogo, tornando-o ainda mais
-                            refinado e polido para os fãs e novos jogadores.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <img src="images/Hollow knight sonhos escondidos grande.webp">
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Lançamento da DLC "Sonhos escondidos"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC "Dreams Escondidos" (Hidden Dreams) é uma das expansões gratuitas lançadas para Hollow
-                            Knight pela Team Cherry. Lançada em agosto de 2017, esta foi a primeira das quatro grandes
-                            atualizações planejadas para o jogo. A DLC adiciona novos chefes, novas mecânicas e alguns
-                            segredos interessantes que enriquecem a experiência de exploração em Hallownest. Vamos
-                            explorar os principais aspectos dessa atualização:</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Principais Recursos e Adições da DLC "Dreams Escondidos"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Novos Chefes dos Sonhos - "Warriors of Dream"</p>
-                    </div>
-                    <div id="dov">
-                        <p>White Defender: Uma versão dos sonhos de um dos chefes já existentes, o Dung Defender.
-                            Encontrado em um local secreto na Cidade das Lágrimas (City of Tears), o White Defender
-                            apresenta novos padrões de ataque e oferece uma batalha mais difícil e estilizada.</p>
-                    </div>
-                    <div id="dov">
-                        <p>Grey Prince Zote: Uma versão fantasiada e muito mais poderosa de Zote the Mighty, baseado nas
-                            histórias que Bretta imagina em sua mente. Ele é encontrado no Refúgio de Bretta (Bretta's
-                            Hut) após coletar uma certa quantidade de Essência. Este chefe é notório por sua
-                            imprevisibilidade e variedade de ataques.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Estações de Travessia - "Dream Gate"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Introduz a habilidade de criar Dream Gates, permitindo aos jogadores marcar pontos
-                            específicos no mundo de Hallownest e viajar rapidamente entre eles. Isso facilita a
-                            navegação e economiza tempo ao explorar áreas extensas ou retornar a locais anteriormente
-                            visitados.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novo Personagem - "The Godseeker"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Esta DLC introduz o Godseeker, um personagem enigmático que desempenha um papel importante em
-                            uma das expansões posteriores, "Godmaster".
-                            O Godseeker oferece desafios adicionais e está relacionado ao aprofundamento do lore do
-                            jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Salão dos Deuses</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Um novo local chamado "Salão dos Deuses" foi adicionado.
-                            Aqui, os jogadores podem enfrentar novamente chefes que já derrotaram no jogo principal, mas
-                            com um nível de dificuldade adicional. Esse local também apresenta desafios boss rush, onde
-                            você pode lutar contra vários chefes consecutivamente.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Estação da Mansão dos Pesadelos</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Uma nova estação de viagem rápida, conhecida como "Estação da Mansão dos Pesadelos", foi
-                            adicionada. Isso facilita a movimentação pelo mundo do jogo e é especialmente útil para
-                            jogadores que buscam explorar cada canto do mapa.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novas Melodias e Música</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Christopher Larkin, o compositor do jogo, adicionou novas trilhas sonoras à DLC, aprimorando
-                            ainda mais a atmosfera rica e imersiva de "Hollow Knight".</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novo Sistema de Diálogos</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Sonhos Escondidos" introduz novos diálogos e interações com NPCs, expandindo o lore e a
-                            história do jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Qualidade de Vida e Melhorias Gerais</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC também trouxe várias melhorias de qualidade de vida e balanceamentos no jogo,
-                            aprimorando a experiência geral para os jogadores.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Importância e Recepção</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Sonhos Escondidos" é uma das várias atualizações que a Team Cherry lançou para "Hollow
-                            Knight" sem custos adicionais, o que foi amplamente elogiado pela comunidade de jogadores.
-                            Essa expansão, em particular, foi apreciada por adicionar mais desafios e conteúdo para
-                            explorar, ao mesmo tempo em que enriquece a narrativa e o mundo do jogo.
-                            A abordagem da Team Cherry de fornecer conteúdo adicional gratuito foi vista como uma
-                            prática exemplar na indústria de jogos, solidificando a reputação de "Hollow Knight" como um
-                            dos melhores jogos indie de todos os tempos.</p>
-                    </div>
-                    <div id="dov">
-                        <img src="Images/Hollow knight DLC Godmaster grande.jpg">
-                    </div>
-                    <br><br>
-                    <div id="dov">
-                        <h3>Lançamento da DLC GODMASTER</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC "Godmaster" é a quarta e última grande atualização gratuita para "Hollow Knight",
-                            lançada pela Team Cherry em 23 de agosto de 2018. Ela adiciona uma quantidade significativa
-                            de novos conteúdos e desafios ao já extenso jogo, focando principalmente em combates
-                            intensos e oportunidades para os jogadores testarem suas habilidades contra os chefes mais
-                            poderosos do jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Principais Características de "Godmaster"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Panteões dos Deuses</p>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC introduz uma nova área chamada "Panteões dos Deuses", que é uma série de arenas onde os
-                            jogadores podem enfrentar chefes em sequência. Esses panteões são divididos em várias
-                            dificuldades, cada uma com uma série de lutas de chefes que se tornam progressivamente mais
-                            desafiadoras. Os panteões também incluem versões mais difíceis de chefes existentes, bem
-                            como alguns novos.
-                            Os panteões oferecem aos jogadores a chance de lutar contra todos os chefes em um único
-                            desafio contínuo, testando a resistência e a habilidade em combates prolongados.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novos Chefes</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Godmaster" apresenta vários novos chefes, incluindo versões alternativas de chefes
-                            existentes e personagens completamente novos. Entre eles estão:</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Sly: Um dos NPCs do jogo que revela suas habilidades escondidas como um mestre do combate.
-                        </p>
-                    </div>
-                    <br><br>
-                    <div id="dov">
-                        <p>Pure Vessel: Uma versão purificada e ainda mais desafiadora do chefe Hollow Knight.</p>
-                    </div>
-                    <br><br>
-                    <div id="dov">
-                        <p>Absolute Radiance: Uma versão ainda mais poderosa do chefe final do jogo principal, a Radiance.
-                        </p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Painmaster Oro e Nailmaster Mato: Dois irmãos mestres do combate que se unem contra o jogador.
-                            Além desses, há versões "God Tamer" dos chefes, que são variantes mais difíceis encontradas nos
-                            Panteões.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Godseeker Mode</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Um novo modo de jogo, chamado "Godseeker Mode", é desbloqueado após completar certos desafios nos
-                            Panteões.
-                            Esse modo oferece uma experiência focada nos combates com chefes, sem a necessidade de explorar
-                            o mundo inteiro do jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novos Encantos e Ferramentas</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC adiciona novos encantos e habilidades que os jogadores podem usar para enfrentar os
-                            desafios dos Panteões.
-                            Entre esses estão encantos que modificam o estilo de jogo e novas combinações para os jogadores
-                            experimentarem.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Expansão da Trilha Sonora</h3>
-                    </div>
-                    <div id="dov">
-                        <p>Christopher Larkin, o compositor do jogo, adicionou novas músicas à trilha sonora para acompanhar
-                            as intensas batalhas dos Panteões, enriquecendo ainda mais a atmosfera épica de "Hollow Knight".
-                        </p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3> História e Lore Expandido</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC "Godmaster" expande a narrativa do jogo, introduzindo novos personagens como o Godseeker e
-                            revelando mais sobre o passado e a mitologia do mundo de Hallownest.
-                            Os jogadores podem descobrir mais sobre a história e os segredos dos deuses antigos ao explorar
-                            os Panteões e interagir com novos NPCs.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Desafios Adicionais</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Godmaster" não só oferece novos chefes e lutas mais difíceis, mas também inclui desafios
-                            adicionais que testam a habilidade e a paciência dos jogadores, como modos de corrida contra o
-                            tempo e desafios boss rush.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Recepção e Impacto</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"Godmaster" foi amplamente aclamada por adicionar um nível significativo de replay e desafio ao
-                            "Hollow Knight". A complexidade e a dificuldade dos novos conteúdos foram especialmente
-                            apreciadas por jogadores que buscavam testar seus limites após completarem o jogo principal. A
-                            expansão consolidou "Hollow Knight" como um título que recompensa a habilidade e a dedicação,
-                            com combates de chefes que são alguns dos mais memoráveis e exigentes da era moderna dos jogos
-                            indie.
-                            Essa DLC, junto com as outras atualizações gratuitas, reforçou a reputação da Team Cherry como
-                            um estúdio dedicado a oferecer valor incrível aos jogadores, elevando ainda mais o status de
-                            "Hollow Knight" como um clássico instantâneo na cena dos jogos independentes.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <img src="images/Hollow-Knight novo-DLC-Pale-Cour.jpg">
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Lançamento da DLC The Pale Court"</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A última expansão notável para "Hollow Knight" chamada "O Palácio da Corte" não é, na verdade,
-                            uma DLC oficial desenvolvida pela Team Cherry, mas um mod criado por fãs, conhecido como "The
-                            Pale Court".
-                            Esse modo foi lançado pela comunidade de modders de "Hollow Knight" em 1º de julho de 2023,
-                            trazendo novos desafios e conteúdos que poderiam facilmente ser confundidos com um lançamento
-                            oficial.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Principais Características de "The Pale Court"</h3>
-                    </div>
-                    <div id="dov">
-                        <p> Foco nos Cinco Grandes Cavaleiros</p>
-                    </div>
-                    <div id="dov">
-                        <p>"The Pale Court" concentra-se nos Cinco Grandes Cavaleiros de Hallownest, figuras lendárias no
-                            lore de "Hollow Knight".
-                            Cada um dos cavaleiros, exceto Ogrim (que já é um chefe no jogo base), é introduzido como um
-                            novo chefe no modo.
-                            Os jogadores podem enfrentar versões "sonhadas" desses cavaleiros, oferecendo um desafio
-                            adicional e expandindo a mitologia do jogo.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3> Novos Chefes</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC inclui chefes como</p>
-                    </div>
-                    <div id="dov">
-                        <p>Hegemol: Um dos grandes cavaleiros, com habilidades focadas em defesa e combate corpo a corpo.
-                        </p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Isma: Conhecida por sua conexão com a natureza e habilidades baseadas em veneno e proteção.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Dryya: Um cavaleiro feroz com habilidades de combate rápidas e poderosas.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <p>Zemir: Possui habilidades misteriosas e de controle de multidões.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Novos Encantos e Ferramentas</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"The Pale Court" introduz novos encantos que podem ser equipados para modificar e melhorar as
-                            habilidades do Cavaleiro.
-                            Esses encantos adicionam novas formas de jogo e estratégias para enfrentar os desafios dos novos
-                            chefes.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Expansão da História e do Lore</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A expansão aprofunda o lore de Hallownest, oferecendo mais contexto e detalhes sobre os Cinco
-                            Grandes Cavaleiros e seus papéis no reino.
-                            Isso é feito através de novos diálogos, entradas no diário e interações com NPCs.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Desafios e Conteúdo Adicional</h3>
-                    </div>
-                    <div id="dov">
-                        <p>A DLC adiciona novos desafios de plataforma e combate, incluindo áreas difíceis que testam as
-                            habilidades de navegação dos jogadores.
-                            Os desafios são projetados para jogadores que já dominam os elementos básicos do jogo e estão
-                            procurando por conteúdo mais exigente.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Melhorias e Recursos Visuais</h3>
-                    </div>
-                    <div id="dov">
-                        <p>O mod também traz melhorias visuais, com novos cenários e designs de chefe que se integram
-                            perfeitamente ao estilo artístico de "Hollow Knight".
-                            A estética do "Pale Court" é detalhada e consistente com a atmosfera sombria e cativante do jogo
-                            original.</p>
-                        <br><br>
-                    </div>
-                    <div id="dov">
-                        <h3>Recepção e Importância</h3>
-                    </div>
-                    <div id="dov">
-                        <p>"The Pale Court" recebeu aclamação tanto da comunidade de jogadores quanto de críticos por sua
-                            qualidade e fidelidade ao espírito de "Hollow Knight".
-                            Muitos jogadores elogiaram o mod pela forma como expande e aprofunda a experiência de jogo,
-                            oferecendo novos desafios e explorando mais do rico universo de Hallownest.
-                            A criação de "The Pale Court" demonstra a paixão e a criatividade da comunidade de "Hollow
-                            Knight", que continua a manter o jogo vivo e relevante, mesmo anos após seu lançamento original.
-                            Esse mod mostra como os fãs podem contribuir significativamente para o legado de um jogo,
-                            adicionando conteúdo que complementa e enriquece a experiência dos jogadores.</p>
-                    </div>
-                </div>
+          <div id="dov">
+            <h3>Novos Personagens</h3>
+          </div>
+          <div id="dov">
+            Grimm: O líder enigmático da trupe, que guia o Cavaleiro em uma missão peculiar.
+            <br /><br />
+          </div>
+          <div id="dov">
+            Brumm: Um membro da trupe que toca o acordeão e oferece pistas e segredos ao jogador.
+            <br /><br />
+          </div>
+          <div id="dov">
+            Baboons: Pequenos seguidores da trupe, com comportamentos estranhos e divertidos.
+            <br /><br />
+          </div>
+          <div id="dov">
+            Divine: Uma figura feminina da trupe que se instala na vila e oferece melhorias para os amuletos do jogador.
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Chefes</h3>
+          </div>
+          <div id="dov">
+            <p>Grimm: Enfrentado em diferentes formas e dificuldades, ele testa as habilidades do jogador com movimentos rápidos e ataques de fogo. <br /><br /></p>
+          </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </head>
-</body>    
+          <div id="dov">
+            Nightmare King Grimm: Uma versão ainda mais poderosa de Grimm, este chefe é notório por sua dificuldade extrema e padrões de ataque complexos.
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Amuletos</h3>
+          </div>
+          <div id="dov">
+            <p>A DLC introduz novos amuletos que o jogador pode equipar para ganhar habilidades especiais:</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Amuleto do Grimmchild: Concede um familiar que ajuda em combate, evoluindo conforme o jogador coleta as chamas.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Amuletos de Confraria: Opções adicionais oferecidas pela Trupe do Grimm, modificando e melhorando as habilidades do jogador de formas únicas.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Elementos Adicionais</h3>
+          </div>
+          <div id="dov">
+            <p>Conteúdo de História: A DLC expande o lore do mundo de Hollow Knight, oferecendo mais detalhes sobre a misteriosa trupe e sua conexão com Hallownest.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Novos Desafios e Inimigos: Além dos novos chefes, a DLC adiciona novos tipos de inimigos e desafios para os jogadores superarem.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Múltiplos Finais: Dependendo das escolhas do jogador ao longo da missão, diferentes desfechos podem ser alcançados, oferecendo rejogabilidade e variação na narrativa.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Atmosfera e Arte</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A Trupe do Grimm traz uma estética única ao jogo, com sua temática circense sombria e trilha sonora evocativa, composta por Christopher Larkin. A arte e o design de som complementam
+              perfeitamente a sensação misteriosa e encantadora que a DLC busca transmitir.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Impacto e Recepção</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC da Trupe do Grimm foi amplamente aclamada por sua qualidade, desafio e a forma como adiciona profundidade ao já rico mundo de Hollow Knight. Os fãs elogiaram especialmente a
+              batalha contra o Nightmare King Grimm e a atmosfera única que a trupe traz ao jogo. Para jogadores que adoram desafios e estão interessados em explorar mais do lore de Hollow Knight, a
+              Trupe do Grimm é uma adição imperdível ao jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <img src="images/Hollow knight DLC lifeblood.jpg" />
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Lançamento DLC "Sangue Vital</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC "Sangue Vital" (Lifeblood) é uma das atualizações gratuitas lançadas para Hollow Knight pela Team Cherry. Publicada em abril de 2018, esta expansão se concentra em melhorias de
+              qualidade de vida, ajustes de jogabilidade, e algumas adições de conteúdo que refinam ainda mais a experiência de jogo. Vamos explorar os principais aspectos da DLC "Sangue Vital":
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Principais Recursos e Melhorias da DLC "Sangue Vital"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Novo Chefe - Enraged Guardian:Uma versão mais poderosa do chefe já existente, o Crystal Guardian. O Enraged Guardian é encontrado na mesma área (Crystallized Mound), mas oferece um
+              desafio adicional com novos padrões de ataque e maior agressividade.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Nova Área Secreta - Hiveblood</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Introduz a Hiveblood Room, um local secreto onde o jogador pode obter o amuleto Hiveblood. Este amuleto é particularmente útil, pois permite ao jogador regenerar lentamente um ponto de
+              saúde perdido, desde que não sofra dano adicional.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Amuleto "Hiveblood"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Como mencionado, este amuleto regenera um ponto de saúde perdido após um curto período, desde que o jogador não sofra dano adicional nesse ínterim. Ele é especialmente útil para
+              jogadores que preferem uma abordagem mais defensiva.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Alterações Visuais e Áudio</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC trouxe melhorias visuais significativas, incluindo ajustes no sistema de iluminação e efeitos gráficos aprimorados. Além disso, houve ajustes na trilha sonora e efeitos sonoros
+              para melhorar a imersão do jogador.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Aprimoramentos de Interface</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Melhorias na interface do usuário foram implementadas, como ajustes nos menus e melhorias no sistema de mapeamento, tornando mais fácil para os jogadores navegarem pelo mundo de
+              Hallownest.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Balancing e Ajustes de Jogo</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Vários aspectos da jogabilidade foram refinados, incluindo ajustes no comportamento de inimigos, redistribuição de itens e ajustes de dificuldade em certos encontros para equilibrar a
+              experiência de jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novo Conteúdo e Segredos</h3>
+          </div>
+          <div id="dov">
+            <p>A DLC também incluiu novos segredos e conteúdo dispersos pelo mundo do jogo, incentivando os jogadores a explorar áreas anteriormente visitadas com novos olhos.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Impacto da DLC "Sangue Vital"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC "Sangue Vital" não introduziu uma quantidade massiva de novos conteúdos como outras DLCs de Hollow Knight, mas seu foco em refinamentos e melhorias de qualidade de vida foi
+              amplamente apreciado pela comunidade. As alterações e otimizações feitas pela Team Cherry nesta atualização ajudaram a polir ainda mais um jogo já aclamado por sua profundidade e design
+              cuidadoso.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Curiosidades</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Desenvolvimento da Atualização: "Sangue Vital" foi a terceira das quatro grandes atualizações gratuitas planejadas pela Team Cherry para Hollow Knight. As outras são "Hidden Dreams",
+              "The Grimm Troupe" e "Godmaster".
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Nome da DLC: O nome "Sangue Vital" reflete tanto o amuleto Hiveblood quanto a ideia de melhorias fundamentais e essenciais para a experiência de jogo</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Recepção pela Comunidade</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Os jogadores elogiaram "Sangue Vital" por sua capacidade de melhorar o jogo base sem alterar drasticamente a experiência central. As melhorias de performance e as otimizações gráficas
+              ajudaram a tornar o jogo mais acessível e fluido, especialmente para jogadores em plataformas diferentes. Além disso, o novo chefe e as áreas secretas adicionaram novos desafios e
+              segredos, mantendo o espírito de exploração viva.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Conclusão</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "Sangue Vital" é uma atualização que exemplifica o compromisso da Team Cherry com a melhoria contínua e a expansão do mundo de Hollow Knight. Mesmo sem adições gigantescas de conteúdo,
+              ela contribuiu significativamente para a experiência geral do jogo, tornando-o ainda mais refinado e polido para os fãs e novos jogadores.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <img src="images/Hollow knight sonhos escondidos grande.webp" />
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Lançamento da DLC "Sonhos escondidos"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC "Dreams Escondidos" (Hidden Dreams) é uma das expansões gratuitas lançadas para Hollow Knight pela Team Cherry. Lançada em agosto de 2017, esta foi a primeira das quatro grandes
+              atualizações planejadas para o jogo. A DLC adiciona novos chefes, novas mecânicas e alguns segredos interessantes que enriquecem a experiência de exploração em Hallownest. Vamos explorar
+              os principais aspectos dessa atualização:
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Principais Recursos e Adições da DLC "Dreams Escondidos"</h3>
+          </div>
+          <div id="dov">
+            <p>Novos Chefes dos Sonhos - "Warriors of Dream"</p>
+          </div>
+          <div id="dov">
+            <p>
+              White Defender: Uma versão dos sonhos de um dos chefes já existentes, o Dung Defender. Encontrado em um local secreto na Cidade das Lágrimas (City of Tears), o White Defender apresenta
+              novos padrões de ataque e oferece uma batalha mais difícil e estilizada.
+            </p>
+          </div>
+          <div id="dov">
+            <p>
+              Grey Prince Zote: Uma versão fantasiada e muito mais poderosa de Zote the Mighty, baseado nas histórias que Bretta imagina em sua mente. Ele é encontrado no Refúgio de Bretta (Bretta's
+              Hut) após coletar uma certa quantidade de Essência. Este chefe é notório por sua imprevisibilidade e variedade de ataques.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Estações de Travessia - "Dream Gate"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Introduz a habilidade de criar Dream Gates, permitindo aos jogadores marcar pontos específicos no mundo de Hallownest e viajar rapidamente entre eles. Isso facilita a navegação e
+              economiza tempo ao explorar áreas extensas ou retornar a locais anteriormente visitados.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novo Personagem - "The Godseeker"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Esta DLC introduz o Godseeker, um personagem enigmático que desempenha um papel importante em uma das expansões posteriores, "Godmaster". O Godseeker oferece desafios adicionais e está
+              relacionado ao aprofundamento do lore do jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Salão dos Deuses</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Um novo local chamado "Salão dos Deuses" foi adicionado. Aqui, os jogadores podem enfrentar novamente chefes que já derrotaram no jogo principal, mas com um nível de dificuldade
+              adicional. Esse local também apresenta desafios boss rush, onde você pode lutar contra vários chefes consecutivamente.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Estação da Mansão dos Pesadelos</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Uma nova estação de viagem rápida, conhecida como "Estação da Mansão dos Pesadelos", foi adicionada. Isso facilita a movimentação pelo mundo do jogo e é especialmente útil para jogadores
+              que buscam explorar cada canto do mapa.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novas Melodias e Música</h3>
+          </div>
+          <div id="dov">
+            <p>Christopher Larkin, o compositor do jogo, adicionou novas trilhas sonoras à DLC, aprimorando ainda mais a atmosfera rica e imersiva de "Hollow Knight".</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novo Sistema de Diálogos</h3>
+          </div>
+          <div id="dov">
+            <p>"Sonhos Escondidos" introduz novos diálogos e interações com NPCs, expandindo o lore e a história do jogo.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Qualidade de Vida e Melhorias Gerais</h3>
+          </div>
+          <div id="dov">
+            <p>A DLC também trouxe várias melhorias de qualidade de vida e balanceamentos no jogo, aprimorando a experiência geral para os jogadores.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Importância e Recepção</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "Sonhos Escondidos" é uma das várias atualizações que a Team Cherry lançou para "Hollow Knight" sem custos adicionais, o que foi amplamente elogiado pela comunidade de jogadores. Essa
+              expansão, em particular, foi apreciada por adicionar mais desafios e conteúdo para explorar, ao mesmo tempo em que enriquece a narrativa e o mundo do jogo. A abordagem da Team Cherry de
+              fornecer conteúdo adicional gratuito foi vista como uma prática exemplar na indústria de jogos, solidificando a reputação de "Hollow Knight" como um dos melhores jogos indie de todos os
+              tempos.
+            </p>
+          </div>
+          <div id="dov">
+            <img src="Images/Hollow knight DLC Godmaster grande.jpg" />
+          </div>
+          <br /><br />
+          <div id="dov">
+            <h3>Lançamento da DLC GODMASTER</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC "Godmaster" é a quarta e última grande atualização gratuita para "Hollow Knight", lançada pela Team Cherry em 23 de agosto de 2018. Ela adiciona uma quantidade significativa de
+              novos conteúdos e desafios ao já extenso jogo, focando principalmente em combates intensos e oportunidades para os jogadores testarem suas habilidades contra os chefes mais poderosos do
+              jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Principais Características de "Godmaster"</h3>
+          </div>
+          <div id="dov">
+            <p>Panteões dos Deuses</p>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC introduz uma nova área chamada "Panteões dos Deuses", que é uma série de arenas onde os jogadores podem enfrentar chefes em sequência. Esses panteões são divididos em várias
+              dificuldades, cada uma com uma série de lutas de chefes que se tornam progressivamente mais desafiadoras. Os panteões também incluem versões mais difíceis de chefes existentes, bem como
+              alguns novos. Os panteões oferecem aos jogadores a chance de lutar contra todos os chefes em um único desafio contínuo, testando a resistência e a habilidade em combates prolongados.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Chefes</h3>
+          </div>
+          <div id="dov">
+            <p>"Godmaster" apresenta vários novos chefes, incluindo versões alternativas de chefes existentes e personagens completamente novos. Entre eles estão:</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Sly: Um dos NPCs do jogo que revela suas habilidades escondidas como um mestre do combate.</p>
+          </div>
+          <br /><br />
+          <div id="dov">
+            <p>Pure Vessel: Uma versão purificada e ainda mais desafiadora do chefe Hollow Knight.</p>
+          </div>
+          <br /><br />
+          <div id="dov">
+            <p>Absolute Radiance: Uma versão ainda mais poderosa do chefe final do jogo principal, a Radiance.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>
+              Painmaster Oro e Nailmaster Mato: Dois irmãos mestres do combate que se unem contra o jogador. Além desses, há versões "God Tamer" dos chefes, que são variantes mais difíceis encontradas
+              nos Panteões.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Godseeker Mode</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Um novo modo de jogo, chamado "Godseeker Mode", é desbloqueado após completar certos desafios nos Panteões. Esse modo oferece uma experiência focada nos combates com chefes, sem a
+              necessidade de explorar o mundo inteiro do jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Encantos e Ferramentas</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC adiciona novos encantos e habilidades que os jogadores podem usar para enfrentar os desafios dos Panteões. Entre esses estão encantos que modificam o estilo de jogo e novas
+              combinações para os jogadores experimentarem.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Expansão da Trilha Sonora</h3>
+          </div>
+          <div id="dov">
+            <p>
+              Christopher Larkin, o compositor do jogo, adicionou novas músicas à trilha sonora para acompanhar as intensas batalhas dos Panteões, enriquecendo ainda mais a atmosfera épica de "Hollow
+              Knight".
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>História e Lore Expandido</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC "Godmaster" expande a narrativa do jogo, introduzindo novos personagens como o Godseeker e revelando mais sobre o passado e a mitologia do mundo de Hallownest. Os jogadores podem
+              descobrir mais sobre a história e os segredos dos deuses antigos ao explorar os Panteões e interagir com novos NPCs.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Desafios Adicionais</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "Godmaster" não só oferece novos chefes e lutas mais difíceis, mas também inclui desafios adicionais que testam a habilidade e a paciência dos jogadores, como modos de corrida contra o
+              tempo e desafios boss rush.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Recepção e Impacto</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "Godmaster" foi amplamente aclamada por adicionar um nível significativo de replay e desafio ao "Hollow Knight". A complexidade e a dificuldade dos novos conteúdos foram especialmente
+              apreciadas por jogadores que buscavam testar seus limites após completarem o jogo principal. A expansão consolidou "Hollow Knight" como um título que recompensa a habilidade e a
+              dedicação, com combates de chefes que são alguns dos mais memoráveis e exigentes da era moderna dos jogos indie. Essa DLC, junto com as outras atualizações gratuitas, reforçou a
+              reputação da Team Cherry como um estúdio dedicado a oferecer valor incrível aos jogadores, elevando ainda mais o status de "Hollow Knight" como um clássico instantâneo na cena dos jogos
+              independentes.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <img src="images/Hollow-Knight novo-DLC-Pale-Cour.jpg" />
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Lançamento da DLC The Pale Court"</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A última expansão notável para "Hollow Knight" chamada "O Palácio da Corte" não é, na verdade, uma DLC oficial desenvolvida pela Team Cherry, mas um mod criado por fãs, conhecido como
+              "The Pale Court". Esse modo foi lançado pela comunidade de modders de "Hollow Knight" em 1º de julho de 2023, trazendo novos desafios e conteúdos que poderiam facilmente ser confundidos
+              com um lançamento oficial.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Principais Características de "The Pale Court"</h3>
+          </div>
+          <div id="dov">
+            <p>Foco nos Cinco Grandes Cavaleiros</p>
+          </div>
+          <div id="dov">
+            <p>
+              "The Pale Court" concentra-se nos Cinco Grandes Cavaleiros de Hallownest, figuras lendárias no lore de "Hollow Knight". Cada um dos cavaleiros, exceto Ogrim (que já é um chefe no jogo
+              base), é introduzido como um novo chefe no modo. Os jogadores podem enfrentar versões "sonhadas" desses cavaleiros, oferecendo um desafio adicional e expandindo a mitologia do jogo.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Chefes</h3>
+          </div>
+          <div id="dov">
+            <p>A DLC inclui chefes como</p>
+          </div>
+          <div id="dov">
+            <p>Hegemol: Um dos grandes cavaleiros, com habilidades focadas em defesa e combate corpo a corpo.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Isma: Conhecida por sua conexão com a natureza e habilidades baseadas em veneno e proteção.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Dryya: Um cavaleiro feroz com habilidades de combate rápidas e poderosas.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <p>Zemir: Possui habilidades misteriosas e de controle de multidões.</p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Novos Encantos e Ferramentas</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "The Pale Court" introduz novos encantos que podem ser equipados para modificar e melhorar as habilidades do Cavaleiro. Esses encantos adicionam novas formas de jogo e estratégias para
+              enfrentar os desafios dos novos chefes.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Expansão da História e do Lore</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A expansão aprofunda o lore de Hallownest, oferecendo mais contexto e detalhes sobre os Cinco Grandes Cavaleiros e seus papéis no reino. Isso é feito através de novos diálogos, entradas
+              no diário e interações com NPCs.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Desafios e Conteúdo Adicional</h3>
+          </div>
+          <div id="dov">
+            <p>
+              A DLC adiciona novos desafios de plataforma e combate, incluindo áreas difíceis que testam as habilidades de navegação dos jogadores. Os desafios são projetados para jogadores que já
+              dominam os elementos básicos do jogo e estão procurando por conteúdo mais exigente.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Melhorias e Recursos Visuais</h3>
+          </div>
+          <div id="dov">
+            <p>
+              O mod também traz melhorias visuais, com novos cenários e designs de chefe que se integram perfeitamente ao estilo artístico de "Hollow Knight". A estética do "Pale Court" é detalhada e
+              consistente com a atmosfera sombria e cativante do jogo original.
+            </p>
+            <br /><br />
+          </div>
+          <div id="dov">
+            <h3>Recepção e Importância</h3>
+          </div>
+          <div id="dov">
+            <p>
+              "The Pale Court" recebeu aclamação tanto da comunidade de jogadores quanto de críticos por sua qualidade e fidelidade ao espírito de "Hollow Knight". Muitos jogadores elogiaram o mod
+              pela forma como expande e aprofunda a experiência de jogo, oferecendo novos desafios e explorando mais do rico universo de Hallownest. A criação de "The Pale Court" demonstra a paixão e
+              a criatividade da comunidade de "Hollow Knight", que continua a manter o jogo vivo e relevante, mesmo anos após seu lançamento original. Esse mod mostra como os fãs podem contribuir
+              significativamente para o legado de um jogo, adicionando conteúdo que complementa e enriquece a experiência dos jogadores.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,106 +1,103 @@
-body{
-    background-color:rgb(34,34,34);
-    color:white;
-    font-family:Arial, Helvetica, sans-serif;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 15px;
+body {
+  background-color: rgb(34, 34, 34);
+  color: white;
+  font-family: Arial, Helvetica, sans-serif;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 15px;
 }
 
-header{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 }
 
-#title{
-    flex-direction: column;
-    line-height: 10px;
-
+#title {
+  flex-direction: column;
+  line-height: 10px;
 }
-li{
-    display: inline-block;
-    margin: 20px;
-
+li {
+  display: inline-block;
+  margin: 20px;
 }
-a{
-    color: white;
+a {
+  color: white;
 }
-a:hover{
-    color: blue;
-    transition: 0.3s all;
+a:hover {
+  color: blue;
+  transition: 0.3s all;
 }
-#Onde-comprar-btn{
-    border: 2px solid blue;
-    padding: 10px;
-    border-radius: 15px;
-
-
+#Onde-comprar-btn {
+  border: 2px solid blue;
+  padding: 10px;
+  border-radius: 15px;
 }
-h1{
-    font-weight: 200;
-
+h1 {
+  font-weight: 200;
 }
 
-main{
-    display: flex;
-    flex-direction: row;
-    margin-top: 50px;
-
+main {
+  display: flex;
+  flex-direction: row;
+  margin-top: 50px;
 }
 
-h2{
-    font-size: 56px;
-    line-height: 10px;
-    font-family: Arial, Helvetica, sans-serif;
+h2 {
+  font-size: 56px;
+  line-height: 10px;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-span{
-    color:rgb(34,34,34);
+span {
+  color: rgb(34, 34, 34);
 }
 
-p{
-    line-height: 20px;
-    max-width: 500px;
-    font-family: Arial, Helvetica, sans-serif;
+p {
+  line-height: 20px;
+  max-width: 500px;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-img{
-    width: 480px;
+img {
+  width: 480px;
 }
-form{
-    display: flex;
-    flex-direction: column;
-    width: 70%;
-}
-
-
-form[type="submit"]:hover{
-    height: 50px;
-    width: 50%;
-    background-color: dodgerblue;
-    color:white;
-    font-weight:bold;
-
-}
-form[type="submit"]:hover{
-    cursor: pointer;
+form {
+  display: flex;
+  flex-direction: column;
+  width: 70%;
 }
 
-input{
-    margin-top: 20px;
-    height: 20px;
-    padding: 15px;
-    border-radius: 20px;
-    border: none;
-    font-size: 15px;
+form[type="submit"]:hover {
+  height: 50px;
+  width: 50%;
+  background-color: dodgerblue;
+  color: white;
+  font-weight: bold;
+}
+form[type="submit"]:hover {
+  cursor: pointer;
 }
 
-#dov{
-    display: flex;
-    justify-content: center;
+input {
+  margin-top: 20px;
+  height: 20px;
+  padding: 15px;
+  border-radius: 20px;
+  border: none;
+  font-size: 15px;
 }
 
+#dov {
+  display: flex;
+  justify-content: center;
+  max-width: 500px;
+}
 
-
+.center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}


### PR DESCRIPTION
O texto da página DLCS não estava respeitando a largura máxima e a centralização

## Mudanças feitas

- A div com class center não tinha estilos de centralização, foram feitos esses estilos e passado a página toda como filha dessa div
- Exclusão de uma tag body duplicada
- Exclusão de uma tag head dentro do body (Não pode)
- Exclusão de tags </p> que estavam fechando sem abrir

## Antes

![image](https://github.com/user-attachments/assets/8b329021-3481-4b90-ac80-d53fdf100ccb)

## Depois

![image](https://github.com/user-attachments/assets/8bf8e2d3-b9f6-44ed-b2f6-3a88fbc062d8)
